### PR TITLE
updates to unified past tense variable naming - installed, notChanged…

### DIFF
--- a/Example/Tests/VersionTests.swift
+++ b/Example/Tests/VersionTests.swift
@@ -199,7 +199,7 @@ class VersionTests: QuickSpec {
                 it("detects updates") {
                     let prevVersion = Version("1.0", buildString: "19", installDate: Date())
                     let curVersion = Version("1.0", buildString: "20", installDate: Date())
-                    expect(Version.changeStateForFromVersion(prevVersion, toVersion: curVersion)).to(equal(Version.ChangeState.update(previousVersion: prevVersion)))
+                    expect(Version.changeStateForFromVersion(prevVersion, toVersion: curVersion)).to(equal(Version.ChangeState.updated(previousVersion: prevVersion)))
                 }
                 it("detects upgrades") {
                     let prevVersion = Version("1.0", buildString: "19", installDate: Date())

--- a/Example/Tests/VersionTrackerTests.swift
+++ b/Example/Tests/VersionTrackerTests.swift
@@ -59,7 +59,7 @@ class VersionTrackerTests: QuickSpec {
                 
                 it("it will notice build Updates") {
                     let versionTracker = VersionTracker(currentVersion: versions[1], inScope: scope, userDefaults: userDefaults)
-                    expect(versionTracker.changeState).to(equal(Version.ChangeState.update(previousVersion: Version("1.0", buildString: "1"))));
+                    expect(versionTracker.changeState).to(equal(Version.ChangeState.updated(previousVersion: Version("1.0", buildString: "1"))));
                 }
                 
                 it("it will notice markting version upgrades") {

--- a/Example/VersionsTracker/AppDelegate.swift
+++ b/Example/VersionsTracker/AppDelegate.swift
@@ -103,7 +103,7 @@ func printVersionChange(_ versionTracker: VersionTracker) {
         print("🆕 Congratulations, the app is launched for the very first time")
     case .notChanged:
         print("🔄 Welcome back, nothing as changed since the last time")
-    case .update(let previousVersion):
+    case .updated(let previousVersion):
         print("🆙 The app was updated making small changes: \(previousVersion) -> \(versionTracker.currentVersion)")
     case .upgraded(let previousVersion):
         print("⬆️ Cool, its a new version: \(previousVersion) -> \(versionTracker.currentVersion)")

--- a/Pod/Classes/Version.swift
+++ b/Pod/Classes/Version.swift
@@ -162,7 +162,7 @@ extension Version {
     public enum ChangeState {
         case installed
         case notChanged
-        case update(previousVersion: Version)
+        case updated(previousVersion: Version)
         case upgraded(previousVersion: Version)
         case downgraded(previousVersion: Version)
     }
@@ -182,7 +182,7 @@ extension Version {
             return .downgraded(previousVersion: olderVersion)
         }
         else if olderVersion != newerVersion {
-            return .update(previousVersion: olderVersion)
+            return .updated(previousVersion: olderVersion)
         }
         return .notChanged
     }
@@ -199,7 +199,7 @@ public func ==(lhs: Version.ChangeState, rhs: Version.ChangeState) -> Bool {
         return true
     case (.notChanged, .notChanged):
         return true
-    case (let .update(previousVersionLHS), let .update(previousVersionRHS)):
+    case (let .updated(previousVersionLHS), let .updated(previousVersionRHS)):
         return previousVersionLHS == previousVersionRHS
     case (let .upgraded(previousVersionLHS), let .upgraded(previousVersionRHS)):
         return previousVersionLHS == previousVersionRHS

--- a/README.md
+++ b/README.md
@@ -88,22 +88,27 @@ let versionsTracker = iDontMindSingletons ? VersionsTracker.sharedInstance : Ver
 
 switch versionsTracker.appVersion.changeState {
 case .installed:
+    break
     // 🎉 Sweet, a new user just installed your app
     // ... start tutorial / intro
 
 case .notChanged:
+    break
     // 😴 nothing as changed
     // ... nothing to do
 
-case .update(let previousVersion: Version):
+case .updated(let previousVersion: Version):
+    break
     // 🙃 new build of the same version
     // ... hopefully it fixed those bugs the QA guy reported
 
 case .upgraded(let previousVersion: Version)
+    break
     // 😄 marketing version increased
     // ... migrate old app data
 
 case .downgraded(let previousVersion: Version)
+    break
     // 😵 marketing version decreased (hopefully we are not on production)
     // ... purge app data and start over
 


### PR DESCRIPTION
Just a minor detail. I thought it would make sense to use the same grammar for the verbs that describe the current version state.

Also I added `break` to the demo switch case of the README.md to make copy & paste available without editing the code.
